### PR TITLE
Update users_list.tpl to display account type

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/users_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/users_list.tpl
@@ -9,6 +9,10 @@
         </span>
         <br/>
 
+        <span>
+            <a href="{config.relative_path}/user/{users.userslug}">{users.accounttype}</a>
+        </span>
+
         <!-- IF section_online -->
         <div class="lastonline">
             <span class="timeago" title="{users.lastonlineISO}"></span>


### PR DESCRIPTION
Updated users_list.tpl to display account type (whether that is instructor, TA, or student) under where the username is currently displayed. This is the initial setup/experimentation to build on when implementing endorsement feature in user story #6. 